### PR TITLE
Fix up some option stuff

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ function form(content, transition, force) {
 
   function onChange(key) {
     return function(e) {
-      var val = e.target.options ?
+      var val = (e.target.options && e.target.multiple) ?
         getSelectedOptions(e.target)
         : e.target.value;
 


### PR DESCRIPTION
Give options a blank. Also give the select a single value unless the select is specifically multiple—this seems to fix the problem with forms sometimes being sent using GET (I think the exception stopped the script that would have called `e.preventDefault()` and so the form was sent non-ajaxy, and since the `<form>` element didn't have a method, it defaulted to `GET`. Without the exception, things seem to work just fine...so far.
